### PR TITLE
#5 Add handleShowMore

### DIFF
--- a/src/content.js
+++ b/src/content.js
@@ -6,7 +6,7 @@ const LIST_LAYOUT_CHOOSER_SELECTOR = 'div[data-control-id="ListLayoutChooser"]:n
 const LIST_OPTION_DIV_SELECTOR = 'div[data-control-id="0"]';
 const LIST_VIEW_ICON_SELECTOR = 'i:not([data-is-focusable="false"]).icon-NotBrickView';
 
-const FAST_TAB_SELECTOR = '.show-more-fields-button';
+const FAST_TAB_SHOW_MORE_SELECTOR = '.show-more-fields-button';
 
 const config = { subtree: true, childList: true };
 
@@ -47,7 +47,7 @@ function handleWideToggleButton(iframeDocument) {
 
 function handleShowMore(document) {
   try {
-    const buttons = document.querySelectorAll(FAST_TAB_SELECTOR);
+    const buttons = document.querySelectorAll(FAST_TAB_SHOW_MORE_SELECTOR);
 
     buttons.forEach((button, index) => {
       button.addEventListener('click', (event) => {

--- a/src/content.js
+++ b/src/content.js
@@ -6,6 +6,8 @@ const LIST_LAYOUT_CHOOSER_SELECTOR = 'div[data-control-id="ListLayoutChooser"]:n
 const LIST_OPTION_DIV_SELECTOR = 'div[data-control-id="0"]';
 const LIST_VIEW_ICON_SELECTOR = 'i:not([data-is-focusable="false"]).icon-NotBrickView';
 
+const FAST_TAB_SELECTOR = '.show-more-fields-button';
+
 const config = { subtree: true, childList: true };
 
 const observer = new MutationObserver(mutations => {
@@ -23,6 +25,7 @@ function handlePageChange() {
     const iframeDocument = iframe.contentWindow.document;
     if (iframeDocument) {
       handleWideToggleButton(iframeDocument);
+      handleFastTabs(iframeDocument);
 
       setTimeout(() => {
         handleListViewSelection(iframeDocument);
@@ -39,6 +42,28 @@ function handleWideToggleButton(iframeDocument) {
     }
   } catch (error) {
     console.error('Error handling wide toggle button:', error);
+  }
+}
+
+function handleFastTabs(document) {
+  try {
+    const buttons = document.querySelectorAll(FAST_TAB_SELECTOR);
+
+    buttons.forEach((button, index) => {
+      button.addEventListener('click', (event) => {
+        if (!button.getAttribute('bc-maximizer-clicked')) {
+          button.setAttribute('bc-maximizer-clicked', 'true');
+        }
+      });
+    });
+
+    buttons.forEach((button, index) => {
+      if (!button.getAttribute('bc-maximizer-clicked')) {
+        button.click();
+      };
+    });
+  } catch (error) {
+    console.error('Error handling FastTab click: ', error);
   }
 }
 

--- a/src/content.js
+++ b/src/content.js
@@ -25,7 +25,7 @@ function handlePageChange() {
     const iframeDocument = iframe.contentWindow.document;
     if (iframeDocument) {
       handleWideToggleButton(iframeDocument);
-      handleFastTabs(iframeDocument);
+      handleShowMore(iframeDocument);
 
       setTimeout(() => {
         handleListViewSelection(iframeDocument);
@@ -45,7 +45,7 @@ function handleWideToggleButton(iframeDocument) {
   }
 }
 
-function handleFastTabs(document) {
+function handleShowMore(document) {
   try {
     const buttons = document.querySelectorAll(FAST_TAB_SELECTOR);
 


### PR DESCRIPTION
Attempts to close #5.

First draft. Not a good solution to add an additional attribute to the element, but the first one that came to my mind after noticing that the event triggers the handling twice in a row, which results in the click being executed twice, which ultimately negates expanding the “show more” page.